### PR TITLE
修改pdfjs引用版本

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yofc-vue-pdfjs",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "yofc-vue-pdf.js",
   "main": "src/index.vue",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "loader-utils": "^1.2.3",
-    "pdfjs-dist": "^2.5.207",
+    "pdfjs-dist": "~2.5.207",
     "raw-loader": "^3.1.0",
     "vue-resize-sensor": "^2.0.0"
   }


### PR DESCRIPTION
需要再合并一下，之前的小尖号会下载2.8的pdfjs版本，这版本中没有es5兼容的文件夹了